### PR TITLE
(#654276518) - ​AACKUser, on the CDB page, when I reduce the column width of a column with a dropdown, the text does not overflow to other cells and ellipses appear, showing the text has been cut short

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crcdevops/open-source-design-system",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",

--- a/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
+++ b/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
@@ -6,7 +6,7 @@ import SelectArrowIcon from "../../../../assets/select-arrow-icon.svg"
 export const Wrapper = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  width: calc(100% - 25px);
+  width: calc(100% - 20px);
   :after {
     content: url("${SelectArrowIcon}");
     position: absolute;

--- a/src/components/organism/Table/CellRenderers/tests/__snapshots__/SelectValueRenderer.test.js.snap
+++ b/src/components/organism/Table/CellRenderers/tests/__snapshots__/SelectValueRenderer.test.js.snap
@@ -10,7 +10,7 @@ exports[`Wrapper should match snapshot 1`] = `
 .c0 {
   overflow: hidden;
   text-overflow: ellipsis;
-  width: calc(100% - 25px);
+  width: calc(100% - 20px);
 }
 
 .c0:after {
@@ -44,7 +44,7 @@ exports[`Wrapper should match snapshot 1`] = `
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
-            "overflow:hidden;text-overflow:ellipsis;width:calc(100% - 25px);:after{content:url(\\"",
+            "overflow:hidden;text-overflow:ellipsis;width:calc(100% - 20px);:after{content:url(\\"",
             ".styledComponentId",
             "\\");position:absolute;top:0.55rem;right:0.55rem;transition:opacity 0.15s;opacity:0;}:hover,:focus{cursor:pointer;:after{opacity:1;}}",
           ],


### PR DESCRIPTION
Before submitting my PR to Code Review, I have made sure:

- [ ] I have run the tests using `yarn run test`
- [ ] I have exported any new files in index.js
- [ ] My file supports Formik if will potentially be used in a form
- [ ] The PR name follows the convention `(#<ticket_number>) - <ticket_user_story>`
- [ ] I have incremented the version in `package.json` if I want to publish a new version
- [ ] If my change is breaking I have updated the minor version number(i.e. the middle one) and don't merge until I have the PR on Corazon ready

