### PR TITLE
(#654276518) - ​AACKUser, on the CDB page, when I reduce the column width of a column with a dropdown, the text does not overflow to other cells and ellipses appear, showing the text has been cut short

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crcdevops/open-source-design-system",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",

--- a/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
+++ b/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
@@ -4,6 +4,7 @@ import styled from "styled-components"
 import SelectArrowIcon from "../../../../assets/select-arrow-icon.svg"
 
 export const Wrapper = styled.div`
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
   width: calc(100% - 20px);
@@ -32,7 +33,7 @@ class SelectValueRenderer extends React.Component {
       this.props.colDef.cellEditorParams.values &&
       this.props.colDef.cellEditorParams.values.find(option => option.value === this.props.value)
 
-    return fullOption ? fullOption.label : this.props.value
+    return (fullOption ? fullOption.label : this.props.value) || " "
   }
 
   render = () => <Wrapper>{this.renderValue()}</Wrapper>

--- a/src/components/organism/Table/CellRenderers/tests/SelectValueRenderer.test.js
+++ b/src/components/organism/Table/CellRenderers/tests/SelectValueRenderer.test.js
@@ -27,9 +27,9 @@ describe("SelectValueRenderer", () => {
     expect(component.instance().renderValue()).toEqual("girls")
   })
 
-  it("should render the given falsy value", () => {
+  it("should render a string with a space when given a falsy value to ensure the cursor is still a pointer on hover", () => {
     const component = shallow(<SelectValueRenderer {...commonProps} value={null} />)
-    expect(component.instance().renderValue()).toBeFalsy()
+    expect(component.instance().renderValue()).toEqual(" ")
   })
 
   it("should render the label of the given value from the options", () => {

--- a/src/components/organism/Table/CellRenderers/tests/__snapshots__/SelectValueRenderer.test.js.snap
+++ b/src/components/organism/Table/CellRenderers/tests/__snapshots__/SelectValueRenderer.test.js.snap
@@ -8,6 +8,7 @@ exports[`SelectValueRenderer should match snapshot 1`] = `
 
 exports[`Wrapper should match snapshot 1`] = `
 .c0 {
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
   width: calc(100% - 20px);
@@ -44,7 +45,7 @@ exports[`Wrapper should match snapshot 1`] = `
           "isStatic": false,
           "lastClassName": "c0",
           "rules": Array [
-            "overflow:hidden;text-overflow:ellipsis;width:calc(100% - 20px);:after{content:url(\\"",
+            "white-space:pre;overflow:hidden;text-overflow:ellipsis;width:calc(100% - 20px);:after{content:url(\\"",
             ".styledComponentId",
             "\\");position:absolute;top:0.55rem;right:0.55rem;transition:opacity 0.15s;opacity:0;}:hover,:focus{cursor:pointer;:after{opacity:1;}}",
           ],


### PR DESCRIPTION
Before submitting my PR to Code Review, I have made sure:

- [ ] I have run the tests using `yarn run test`
- [ ] I have exported any new files in index.js
- [ ] My file supports Formik if will potentially be used in a form
- [ ] The PR name follows the convention `(#<ticket_number>) - <ticket_user_story>`
- [ ] I have incremented the version in `package.json` if I want to publish a new version
- [ ] If my change is breaking I have updated the minor version number(i.e. the middle one) and don't merge until I have the PR on Corazon ready

