### PR TITLE
774008876 - AAUser on the CDB when I single click to open up the cell editor on a dropdown field It should open the dropdown cell editor on that cell (not another cell in the same column but different row)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crcdevops/open-source-design-system",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",

--- a/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
+++ b/src/components/organism/Table/CellRenderers/SelectValueRenderer.js
@@ -17,9 +17,9 @@ export const Wrapper = styled.div`
     transition: opacity 0.15s;
     opacity: 0;
     border: none;
-    color: ${props => props.theme.action.main.hex};
+    color: ${(props) => props.theme.action.main.hex};
     path {
-      fill: ${props => props.theme.action.main.hex};
+      fill: ${(props) => props.theme.action.main.hex};
     }
   }
   :hover {
@@ -40,14 +40,14 @@ class SelectValueRenderer extends React.Component {
     const fullOption =
       this.props.colDef.cellEditorParams &&
       this.props.colDef.cellEditorParams.values &&
-      this.props.colDef.cellEditorParams.values.find(option => option.value === this.props.value)
+      this.props.colDef.cellEditorParams.values.find((option) => option.value === this.props.value)
 
     return (fullOption ? fullOption.label : this.props.value) || " "
   }
 
   startEditingCell = () => {
     const {
-      rowIndex,
+      node: { rowIndex },
       colDef: { field },
     } = this.props
 
@@ -75,7 +75,9 @@ SelectValueRenderer.propTypes = {
     }),
     field: PropTypes.string,
   }),
-  rowIndex: PropTypes.number,
+  node: PropTypes.shape({
+    rowIndex: PropTypes.number,
+  }),
   api: PropTypes.shape({
     startEditingCell: PropTypes.func,
   }),

--- a/src/components/organism/Table/CellRenderers/tests/SelectValueRenderer.test.js
+++ b/src/components/organism/Table/CellRenderers/tests/SelectValueRenderer.test.js
@@ -46,12 +46,13 @@ describe("SelectValueRenderer", () => {
         {...commonProps}
         value={null}
         rowIndex={1}
+        node={{ rowIndex: 5 }}
         colDef={{ field: "testCol" }}
       />,
     )
     component.find("button").simulate("click")
     expect(startEditingCellMock).toBeCalledTimes(1)
-    expect(startEditingCellMock).toBeCalledWith({ colKey: "testCol", rowIndex: 1 })
+    expect(startEditingCellMock).toBeCalledWith({ colKey: "testCol", rowIndex: 5 })
   })
 
   it("should render the label of the given value from the options", () => {


### PR DESCRIPTION
Before submitting my PR to Code Review, I have made sure:

- [x] I have run the tests using `yarn run test`
- [x] I have exported any new files in index.js
- [x] My file supports Formik if will potentially be used in a form
- [x] The PR name follows the convention `(#<ticket_number>) - <ticket_user_story>`
- [x] I have incremented the version in `package.json` if I want to publish a new version
- [x] If my change is breaking I have updated the minor version number(i.e. the middle one) and don't merge until I have the PR on Corazon ready

