### PR TITLE
970754069 - Fix modal buttons on older Safari versions and AAUser, when I go to manage a CDB, I see the start/end date cell modals correctly show the date picker tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crcdevops/open-source-design-system",
-  "version": "1.7.24",
+  "version": "1.7.25",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-solid-svg-icons": "^5.7.1",

--- a/src/components/molecules/ConfirmationModal/ConfirmationModal.stories.js
+++ b/src/components/molecules/ConfirmationModal/ConfirmationModal.stories.js
@@ -5,7 +5,20 @@ import { text } from "@storybook/addon-knobs"
 
 import { ConfirmationModal } from "../../../index"
 
-
+const OverflowContent = styled.div`
+  position:relative;
+  div {
+    position:absolute;
+    top:0;
+    left:0;
+    width:80px;
+    height:200px;
+    display:block;
+    background-color:black;
+    color:white;
+    border:3px solid coral;
+  }
+`
 
 storiesOf("Modals", module)
   .add("Confirmation Modal without Title", () => (
@@ -36,5 +49,41 @@ storiesOf("Modals", module)
       <br />
       <br />
       <b>Are you sure want to switch to another user?</b>
+    </ConfirmationModal>
+  ))
+  .add("Confirmation Modal without Title with content overflow", () => (
+    <ConfirmationModal
+      isOpen
+      yesButtonLabel={text("Yes button label", "Button")}
+      noButtonLabel={text("No button label", "Cancel")}
+    >
+      Without a title, we can have text here also.
+      <br />
+      <br />
+      You have clicked on another user whilst still in progress of editing the permissions of
+      Bethany B. If you change users now you will lose the current changes you have made.
+      <br />
+      <br />
+      <b>Are you sure want to switch to another user?</b>
+      <OverflowContent>
+        <div>
+          woooow
+          <br />
+          <br />
+          woooow
+          <br />
+          <br />
+          woooow
+          <br />
+          <br />
+          woooow
+          <br />
+          <br />
+          woooow
+          <br />
+          <br />
+          woooow
+        </div>
+      </OverflowContent>
     </ConfirmationModal>
   ))

--- a/src/components/molecules/ConfirmationModal/ConfirmationModal.test.js
+++ b/src/components/molecules/ConfirmationModal/ConfirmationModal.test.js
@@ -43,8 +43,8 @@ describe("ConfirmationModal Component Test", () => {
       <ConfirmationModal isOpen>I am a lovely confirmation modal</ConfirmationModal>,
     )
 
-    expect(component.find("ButtonText.yesButton").text()).toEqual("Yes")
-    expect(component.find("ButtonText.noButton").text()).toEqual("No")
+    expect(component.find("span.modal_noButtonLabel").text()).toEqual("No")
+    expect(component.find("span.modal_yesButtonLabel").text()).toEqual("Yes")
   })
 
   it("should accept a string/JSX message for the yes button", () => {
@@ -54,11 +54,11 @@ describe("ConfirmationModal Component Test", () => {
       </ConfirmationModal>,
     )
 
-    expect(component.find("ButtonText.yesButton").text()).toEqual("I like to confirm")
+    expect(component.find("span.modal_yesButtonLabel").text()).toEqual("I like to confirm")
 
     const YesJSX = () => <div>Confirm</div>
     component.setProps({ yesButtonLabel: <YesJSX /> })
-    expect(component.find("ButtonText.yesButton").contains(<YesJSX />)).toEqual(true)
+    expect(component.find("span.modal_yesButtonLabel").contains(<YesJSX />)).toEqual(true)
   })
 
   it("should accept a string/JSX message for the no button", () => {
@@ -68,10 +68,10 @@ describe("ConfirmationModal Component Test", () => {
       </ConfirmationModal>,
     )
 
-    expect(component.find("ButtonText.noButton").text()).toEqual("Cancel")
+    expect(component.find("span.modal_noButtonLabel").text()).toEqual("Cancel")
 
     const NoJSX = () => <div>Nope</div>
     component.setProps({ noButtonLabel: <NoJSX /> })
-    expect(component.find("ButtonText.noButton").contains(<NoJSX />)).toEqual(true)
+    expect(component.find("span.modal_noButtonLabel").contains(<NoJSX />)).toEqual(true)
   })
 })

--- a/src/components/molecules/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/molecules/ConfirmationModal/ConfirmationModal.tsx
@@ -61,13 +61,6 @@ export const ContentContainer = styled.p<IWithTitleProps>`
   margin-top: ${({ withTitle }) => (withTitle ? "1.3125rem" : "0")};
 `;
 
-const ButtonText = styled.p`
-  font-size: 0.875rem;
-  line-height: 1.375rem;
-  padding: 0.125rem;
-`;
-
-ButtonText.displayName = "ButtonText";
 
 const customStyles = {
   overlay: {
@@ -77,7 +70,7 @@ const customStyles = {
     alignItems: "center",
   },
   content: {
-    overflow: "hidden",
+    overflow:"visible",
     margin: "auto",
     top: "auto",
     right: "auto",
@@ -126,10 +119,10 @@ export const ConfirmationModal: React.FunctionComponent<IConfirmationModal> = (p
         <ContentContainer withTitle={!!title}>{children}</ContentContainer>
         <ButtonRow>
           <Button onClick={onNo} buttonType="ghost" buttonSize="medium">
-            <ButtonText className="noButton">{noButtonLabel}</ButtonText>
+            <span className="modal_noButtonLabel">{noButtonLabel}</span>
           </Button>
           <Button onClick={onYes} buttonType="primary" buttonSize="medium">
-            <ButtonText className="yesButton">{yesButtonLabel}</ButtonText>
+            <span className="modal_yesButtonLabel">{yesButtonLabel}</span>
           </Button>
         </ButtonRow>
       </InsideContainer>

--- a/src/components/molecules/ConfirmationModal/__snapshots__/ConfirmationModal.test.js.snap
+++ b/src/components/molecules/ConfirmationModal/__snapshots__/ConfirmationModal.test.js.snap
@@ -24,7 +24,7 @@ exports[`ConfirmationModal Component Test Match last snapshot 1`] = `
         "boxShadow": "0px 0px 16px #696969",
         "left": "auto",
         "margin": "auto",
-        "overflow": "hidden",
+        "overflow": "visible",
         "padding": 0,
         "right": "auto",
         "top": "auto",
@@ -185,21 +185,21 @@ exports[`ConfirmationModal Component Test Match last snapshot 1`] = `
         buttonSize="medium"
         buttonType="ghost"
       >
-        <ButtonText
-          className="noButton"
+        <span
+          className="modal_noButtonLabel"
         >
           No
-        </ButtonText>
+        </span>
       </Button>
       <Button
         buttonSize="medium"
         buttonType="primary"
       >
-        <ButtonText
-          className="yesButton"
+        <span
+          className="modal_yesButtonLabel"
         >
           Yes
-        </ButtonText>
+        </span>
       </Button>
     </ConfirmationModal__ButtonRow>
   </ConfirmationModal__InsideContainer>
@@ -230,7 +230,7 @@ exports[`ConfirmationModal Component Test Match last snapshot with title 1`] = `
         "boxShadow": "0px 0px 16px #696969",
         "left": "auto",
         "margin": "auto",
-        "overflow": "hidden",
+        "overflow": "visible",
         "padding": 0,
         "right": "auto",
         "top": "auto",
@@ -394,21 +394,21 @@ exports[`ConfirmationModal Component Test Match last snapshot with title 1`] = `
         buttonSize="medium"
         buttonType="ghost"
       >
-        <ButtonText
-          className="noButton"
+        <span
+          className="modal_noButtonLabel"
         >
           No
-        </ButtonText>
+        </span>
       </Button>
       <Button
         buttonSize="medium"
         buttonType="primary"
       >
-        <ButtonText
-          className="yesButton"
+        <span
+          className="modal_yesButtonLabel"
         >
           Yes
-        </ButtonText>
+        </span>
       </Button>
     </ConfirmationModal__ButtonRow>
   </ConfirmationModal__InsideContainer>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61432158/104717128-c32cdf80-5720-11eb-9d75-52e24552cae5.png)
